### PR TITLE
Crystal-dependent seeding thresholds

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalTrivialConditionRetriever.h
@@ -91,6 +91,8 @@
 #include "CondFormats/DataRecord/interface/EcalMappingElectronicsRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h"
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 
@@ -160,6 +162,8 @@ public:
   virtual std::unique_ptr<EcalClusterEnergyCorrectionObjectSpecificParameters> produceEcalClusterEnergyCorrectionObjectSpecificParameters( const EcalClusterEnergyCorrectionObjectSpecificParametersRcd& );
   virtual std::unique_ptr<EcalPFRecHitThresholds> produceEcalPFRecHitThresholds( const EcalPFRecHitThresholdsRcd& );
   virtual std::unique_ptr<EcalPFRecHitThresholds>  getPFRecHitThresholdsFromConfiguration ( const EcalPFRecHitThresholdsRcd& ) ;
+  virtual std::unique_ptr<EcalPFSeedingThresholds> produceEcalPFSeedingThresholds( const EcalPFSeedingThresholdsRcd& );
+  virtual std::unique_ptr<EcalPFSeedingThresholds>  getPFSeedingThresholdsFromConfiguration ( const EcalPFSeedingThresholdsRcd& ) ;
 
 
   virtual std::unique_ptr<EcalChannelStatus> produceEcalChannelStatus( const EcalChannelStatusRcd& );
@@ -231,6 +235,10 @@ private:
   double pfRecHitThresholdsNSigmasHEta_;
   double pfRecHitThresholdsEB_;
   double pfRecHitThresholdsEE_;
+  double pfSeedingThresholdsNSigmas_;
+  double pfSeedingThresholdsNSigmasHEta_;
+  double pfSeedingThresholdsEB_;
+  double pfSeedingThresholdsEE_;
 
   double sim_pulse_shape_EB_thresh_;
   double sim_pulse_shape_EE_thresh_;
@@ -242,6 +250,8 @@ private:
   
   std::string pfRecHitFile_ ;
   std::string pfRecHitFileEE_ ;
+  std::string pfSeedingFile_ ;
+  std::string pfSeedingFileEE_ ;
   
   std::string EELaserAlphaFile2_;
   
@@ -376,6 +386,7 @@ private:
   bool producedEcalAlignmentES_;
   bool producedEcalSimPulseShape_;
   bool producedEcalPFRecHitThresholds_;
+  bool producedEcalPFSeedingThresholds_;
   bool getEBAlignmentFromFile_;
   bool getEEAlignmentFromFile_;
   bool getESAlignmentFromFile_;

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
@@ -77,6 +77,10 @@ EcalTrivialConditionRetriever::EcalTrivialConditionRetriever( const edm::Paramet
   pfRecHitThresholdsEB_ = ps.getUntrackedParameter<double>("EcalPFRecHitThresholdEB", 0.0 );
   pfRecHitThresholdsEE_ = ps.getUntrackedParameter<double>("EcalPFRecHitThresholdEE", 0.0 );
 
+  pfSeedingThresholdsNSigmas_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdNSigmas", 1.0 );
+  pfSeedingThresholdsNSigmasHEta_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdNSigmasHEta", 1.0 );
+  pfSeedingThresholdsEB_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdEB", 0.0 );
+  pfSeedingThresholdsEE_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdEE", 0.0 );
 
   localContCorrParameters_ = ps.getUntrackedParameter< std::vector<double> >("localContCorrParameters", std::vector<double>(0) );
   crackCorrParameters_ = ps.getUntrackedParameter< std::vector<double> >("crackCorrParameters", std::vector<double>(0) );
@@ -330,6 +334,7 @@ EcalTrivialConditionRetriever::EcalTrivialConditionRetriever( const edm::Paramet
   }
 
    producedEcalPFRecHitThresholds_ = ps.getUntrackedParameter<bool>("producedEcalPFRecHitThresholds", false);
+   producedEcalPFSeedingThresholds_ = ps.getUntrackedParameter<bool>("producedEcalPFSeedingThresholds", false);
 
    // new for PFRecHit Thresholds
    pfRecHitFile_ = ps.getUntrackedParameter<std::string>("PFRecHitFile","");
@@ -343,6 +348,20 @@ EcalTrivialConditionRetriever::EcalTrivialConditionRetriever( const edm::Paramet
          setWhatProduced (this, &EcalTrivialConditionRetriever::produceEcalPFRecHitThresholds ) ;
      }
      findingRecord<EcalPFRecHitThresholdsRcd> () ;
+   }
+
+   // new for PFSeeding Thresholds
+   pfSeedingFile_ = ps.getUntrackedParameter<std::string>("PFSeedingFile","");
+   pfSeedingFileEE_ = ps.getUntrackedParameter<std::string>("PFSeedingFileEE","");
+ 
+ 
+   if (producedEcalPFSeedingThresholds_) { // user asks to produce constants
+     if(!pfSeedingFile_.empty()) {  // if file provided read constants
+         setWhatProduced (this, &EcalTrivialConditionRetriever::getPFSeedingThresholdsFromConfiguration ) ;
+     } else { // set all constants to 0
+         setWhatProduced (this, &EcalTrivialConditionRetriever::produceEcalPFSeedingThresholds ) ;
+     }
+     findingRecord<EcalPFSeedingThresholdsRcd> () ;
    }
 
 
@@ -753,6 +772,44 @@ EcalTrivialConditionRetriever::produceEcalPFRecHitThresholds( const EcalPFRecHit
   return ical;
 }
 
+
+// new for the PF Seeding Thresholds                                                                                                                                        
+
+std::unique_ptr<EcalPFSeedingThresholds>
+EcalTrivialConditionRetriever::produceEcalPFSeedingThresholds( const EcalPFSeedingThresholdsRcd& )
+{
+  auto ical = std::make_unique<EcalPFSeedingThresholds>();
+
+  for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA ;++ieta) {
+    if(ieta==0) continue;
+    for(int iphi=EBDetId::MIN_IPHI; iphi<=EBDetId::MAX_IPHI; ++iphi) {
+      // make an EBDetId since we need EBDetId::rawId() to be used as the key for the pedestals                                                                             
+      if (EBDetId::validDetId(ieta,iphi))
+        {
+          EBDetId ebid(ieta,iphi);
+          ical->setValue( ebid.rawId(), pfSeedingThresholdsEB_  );
+        }
+    }
+  }
+
+  for(int iX=EEDetId::IX_MIN; iX<=EEDetId::IX_MAX ;++iX) {
+    for(int iY=EEDetId::IY_MIN; iY<=EEDetId::IY_MAX; ++iY) {
+      // make an EEDetId since we need EEDetId::rawId() to be used as the key for the pedestals                                                                             
+      if (EEDetId::validDetId(iX,iY,1))
+        {
+          EEDetId eedetidpos(iX,iY,1);
+          ical->setValue( eedetidpos.rawId(), pfSeedingThresholdsEE_ );
+        }
+      if(EEDetId::validDetId(iX,iY,-1))
+        {
+          EEDetId eedetidneg(iX,iY,-1);
+          ical->setValue( eedetidneg.rawId(), pfSeedingThresholdsEE_ );
+        }
+    }
+  }
+
+  return ical;
+}
 
 
 
@@ -3088,6 +3145,93 @@ EcalTrivialConditionRetriever::getPFRecHitThresholdsFromConfiguration
 
 }
 
+// new for the PF Seeding thresholds                                                                                                                                          
+
+std::unique_ptr<EcalPFSeedingThresholds>
+EcalTrivialConditionRetriever::getPFSeedingThresholdsFromConfiguration
+( const EcalPFSeedingThresholdsRcd& )
+{
+  std::unique_ptr<EcalPFSeedingThresholds> ical;
+
+  // Reads the values from a txt file                                                                                                                                          
+
+
+  edm::LogInfo("EcalTrivialConditionRetriever") << "Reading PF Seeding Thresholds from file "
+                                                << pfSeedingFile_.c_str() ;
+
+  ical = std::make_unique<EcalPFSeedingThresholds>();
+  
+  char line[50];
+  
+  FILE *inpFile; // input file                                                                                                                                                
+  inpFile = fopen(pfSeedingFile_.c_str(),"r");
+  int nxt=0;
+  
+  edm::LogInfo ("Going to multiply the sigmas by ")<<pfSeedingThresholdsNSigmas_;
+  edm::LogInfo ("We will print some values ");
+  
+  
+  while (fgets(line,50,inpFile)) {
+    float thresh;
+    int eta=0;
+    int phi=0;
+    int zeta=0;
+    sscanf(line, "%d %d %d %f", &eta, &phi, &zeta, &thresh);
+    
+    thresh=thresh*pfSeedingThresholdsNSigmas_;
+    
+    if(phi==50) edm::LogInfo ("EB ")<< std::dec<<eta <<"/"<< std::dec<<phi <<"/"<<std::dec<<zeta<<" thresh: " <<thresh ;
+    nxt=nxt+1;
+    
+    EBDetId ebid(eta, phi);
+    ical->setValue( ebid, thresh );
+  }
+
+  fclose(inpFile);
+  
+  edm::LogInfo ("Read number of EB crystals: ")<<nxt;
+
+
+  edm::LogInfo ("Now reading the EE file ... ");
+  edm::LogInfo ("We will multiply the sigma in EE by ")<<pfSeedingThresholdsNSigmas_;
+  edm::LogInfo ("We will multiply the sigma in EE at high eta by")<<pfSeedingThresholdsNSigmasHEta_;
+  edm::LogInfo ("We will print some values ");
+  
+
+  FILE *inpFileEE; // input file                                                                                                                                              
+  inpFileEE = fopen(pfSeedingFileEE_.c_str(),"r");
+  nxt=0;
+  
+  while (fgets(line,40,inpFileEE)) {
+    float thresh;
+    int ix=0;
+    int iy=0;
+    int iz=0;
+    sscanf(line, "%d %d %d %f", &ix, &iy,&iz, &thresh);
+
+    double eta= -log(tan(0.5*atan(sqrt((ix-50.5)*(ix-50.5)+
+                                       (iy-50.5)*(iy-50.5))*2.98/328.))); // approx eta 
+
+    if(eta>2.5) {
+      thresh=thresh*pfSeedingThresholdsNSigmasHEta_;
+    } else {
+      thresh=thresh*pfSeedingThresholdsNSigmas_;
+    }
+
+    if(ix==50) edm::LogInfo ("EE ")<<std::dec<<ix<<"/"<<std::dec<<iy<<"/"<<std::dec<<iz<<" thresh: " <<thresh <<" eta="<<eta;
+
+    EEDetId eeid(ix,iy,iz);
+    ical->setValue( eeid, thresh );
+    nxt=nxt+1;
+  }
+
+  fclose(inpFileEE);
+  edm::LogInfo ("Read number of EE crystals: ")<<nxt;
+  edm::LogInfo ("end PF Rec Hits ... ");
+
+  return ical;
+
+}
 
 std::unique_ptr<EcalIntercalibConstantsMC> 
 EcalTrivialConditionRetriever::getIntercalibConstantsMCFromConfiguration 

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalTrivialConditionRetriever.cc
@@ -79,8 +79,8 @@ EcalTrivialConditionRetriever::EcalTrivialConditionRetriever( const edm::Paramet
 
   pfSeedingThresholdsNSigmas_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdNSigmas", 1.0 );
   pfSeedingThresholdsNSigmasHEta_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdNSigmasHEta", 1.0 );
-  pfSeedingThresholdsEB_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdEB", 0.0 );
-  pfSeedingThresholdsEE_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdEE", 0.0 );
+  pfSeedingThresholdsEB_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdEB", 0.2 ); // 80 -> 200 MeV
+  pfSeedingThresholdsEE_ = ps.getUntrackedParameter<double>("EcalPFSeedingThresholdEE", 0.5 ); // 300 -> 500 MeV
 
   localContCorrParameters_ = ps.getUntrackedParameter< std::vector<double> >("localContCorrParameters", std::vector<double>(0) );
   crackCorrParameters_ = ps.getUntrackedParameter< std::vector<double> >("crackCorrParameters", std::vector<double>(0) );

--- a/CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h
+++ b/CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h
@@ -1,0 +1,6 @@
+#ifndef CondFormats_DataRecord_EcalPFSeedingThresholdsRcd_h
+#define CondFormats_DataRecord_EcalPFSeedingThresholdsRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class EcalPFSeedingThresholdsRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalPFSeedingThresholdsRcd> {};
+#endif

--- a/CondFormats/DataRecord/src/EcalPFSeedingThresholdsRcd.cc
+++ b/CondFormats/DataRecord/src/EcalPFSeedingThresholdsRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(EcalPFSeedingThresholdsRcd);

--- a/CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h
+++ b/CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h
@@ -1,0 +1,15 @@
+#ifndef CondFormats_EcalObjects_EcalPFSeedingThresholds_H
+#define CondFormats_EcalObjects_EcalPFSeedingThresholds_H
+/**
+ * Author: Shahram Rahatlou, University of Rome & INFN
+ * Created: 22 Feb 2006
+ * $Id: EcalPFSeedingThresholds.h, 2019/09/05 20:21:42 mratti Exp $
+ **/
+#include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
+
+typedef float EcalPFSeedingThreshold;
+typedef EcalFloatCondObjectContainer EcalPFSeedingThresholdsMap;
+typedef EcalPFSeedingThresholdsMap EcalPFSeedingThresholds;
+
+
+#endif

--- a/IOMC/ParticleGuns/interface/CloseByParticleFlatEtGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByParticleFlatEtGunProducer.h
@@ -1,0 +1,32 @@
+#ifndef IOMC_ParticleGun_CloseByParticleGunProducer_H
+#define IOMC_ParticleGun_CloseByParticleGunProducer_H
+
+#include "IOMC/ParticleGuns/interface/BaseFlatGunProducer.h"
+
+namespace edm
+{
+
+  class CloseByParticleGunProducer : public BaseFlatGunProducer
+  {
+
+  public:
+    CloseByParticleGunProducer(const ParameterSet &);
+    ~CloseByParticleGunProducer() override;
+
+  private:
+
+    void produce(Event & e, const EventSetup& es) override;
+
+  protected :
+
+    // data members
+    double fPtMax,fPtMin,fRMin,fRMax,fZMin,fZMax,fDelta,fPhiMin,fPhiMax;
+    int fNParticles;
+    bool fPointing = false;
+    bool fOverlapping = false;
+    bool fRandomShoot = false;
+    std::vector<int> fPartIDs;
+  };
+}
+
+#endif

--- a/IOMC/ParticleGuns/interface/CloseByParticleFlatEtGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByParticleFlatEtGunProducer.h
@@ -1,17 +1,17 @@
-#ifndef IOMC_ParticleGun_CloseByParticleGunProducer_H
-#define IOMC_ParticleGun_CloseByParticleGunProducer_H
+#ifndef IOMC_ParticleGun_CloseByParticleFlatEtGunProducer_H
+#define IOMC_ParticleGun_CloseByParticleFlatEtGunProducer_H
 
 #include "IOMC/ParticleGuns/interface/BaseFlatGunProducer.h"
 
 namespace edm
 {
 
-  class CloseByParticleGunProducer : public BaseFlatGunProducer
+  class CloseByParticleFlatEtGunProducer : public BaseFlatGunProducer
   {
 
   public:
-    CloseByParticleGunProducer(const ParameterSet &);
-    ~CloseByParticleGunProducer() override;
+    CloseByParticleFlatEtGunProducer(const ParameterSet &);
+    ~CloseByParticleFlatEtGunProducer() override;
 
   private:
 

--- a/IOMC/ParticleGuns/src/CloseByParticleFlatEtGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleFlatEtGunProducer.cc
@@ -77,10 +77,16 @@ void CloseByParticleFlatEtGunProducer::produce(Event &e, const EventSetup& es)
      int partIdx = CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size());
      particles.push_back(fPartIDs[partIdx]);
      }
+   //in the case of the generation in the endcap (i.e at fixed Z), we want to generate randomly between EEP and EEM
+   double rdm = 1;
+   if(fZMin==fZMax){
+      rdm = (std::rand() & 2) - 1;
+      if(rdm==0) rdm = -1;
+   }
 
    double phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
    double fR = CLHEP::RandFlat::shoot(engine,fRMin,fRMax);
-   double fZ = CLHEP::RandFlat::shoot(engine,fZMin,fZMax);
+   double fZ = CLHEP::RandFlat::shoot(engine,rdm*fZMin,rdm*fZMax);
    double tmpPhi = phi;
    double tmpR = fR;
 

--- a/IOMC/ParticleGuns/src/CloseByParticleFlatEtGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleFlatEtGunProducer.cc
@@ -1,0 +1,168 @@
+#include <ostream>
+
+#include "IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
+#include "DataFormats/Math/interface/Vector3D.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "CLHEP/Random/RandFlat.h"
+
+using namespace edm;
+using namespace std;
+
+CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset) :
+   BaseFlatGunProducer(pset)
+{
+
+  ParameterSet defpset ;
+  ParameterSet pgun_params =
+    pset.getParameter<ParameterSet>("PGunParameters") ;
+
+  //fEnMax = pgun_params.getParameter<double>("EnMax");
+  //fEnMin = pgun_params.getParameter<double>("EnMin");
+  fPtMin = pgun_params.getParameter<double>("MinPt");
+  fPtMax = pgun_params.getParameter<double>("MaxPt");
+  fRMax = pgun_params.getParameter<double>("RMax");
+  fRMin = pgun_params.getParameter<double>("RMin");
+  fZMax = pgun_params.getParameter<double>("ZMax");
+  fZMin = pgun_params.getParameter<double>("ZMin");
+  fDelta = pgun_params.getParameter<double>("Delta");
+  fPhiMin = pgun_params.getParameter<double>("MinPhi");
+  fPhiMax = pgun_params.getParameter<double>("MaxPhi");
+  fPointing = pgun_params.getParameter<bool>("Pointing");
+  fOverlapping = pgun_params.getParameter<bool>("Overlapping");
+  fRandomShoot = pgun_params.getParameter<bool>("RandomShoot");
+  fNParticles = pgun_params.getParameter<int>("NParticles");
+  fPartIDs = pgun_params.getParameter< vector<int> >("PartID");
+
+  produces<HepMCProduct>("unsmeared");
+  produces<GenEventInfoProduct>();
+
+}
+
+CloseByParticleGunProducer::~CloseByParticleGunProducer()
+{
+   // no need to cleanup GenEvent memory - done in HepMCProduct
+}
+
+void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
+{
+   edm::Service<edm::RandomNumberGenerator> rng;
+   CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
+
+   if ( fVerbosity > 0 )
+     {
+       LogDebug("CloseByParticleGunProducer") << " CloseByParticleGunProducer : Begin New Event Generation" << endl ;
+     }
+   fEvt = new HepMC::GenEvent() ;
+
+   // loop over particles
+   //
+   int barcode = 1 ;
+   int numParticles = fRandomShoot ? CLHEP::RandFlat::shoot(engine, 1, fNParticles) : fNParticles;
+   std::vector<int> particles;
+
+   for(int i=0; i<numParticles; i++){
+     int partIdx = CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size());
+     particles.push_back(fPartIDs[partIdx]);
+     }
+
+   double phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
+   double fR = CLHEP::RandFlat::shoot(engine,fRMin,fRMax);
+   double fZ = CLHEP::RandFlat::shoot(engine,fZMin,fZMax);
+   double tmpPhi = phi;
+   double tmpR = fR;
+
+   for (unsigned int ip=0; ip<particles.size(); ++ip)
+   {
+     if(fOverlapping)
+       {
+        fR = CLHEP::RandFlat::shoot(engine,tmpR-fDelta,tmpR+fDelta);
+        phi = CLHEP::RandFlat::shoot(engine, tmpPhi-fDelta/fR, tmpPhi+fDelta/fR);
+       }
+     else
+       phi += fDelta/fR;
+ 
+     //generation flat in Energy:
+     //double fEn = CLHEP::RandFlat::shoot(engine,fEnMin,fEnMax);
+     //generation flat in Et:
+     double pt = CLHEP::RandFlat::shoot(engine,fPtMin,fPtMax);
+     int PartID = particles[ip] ;
+     const HepPDT::ParticleData *PData = fPDGTable->particle(HepPDT::ParticleID(abs(PartID))) ;
+     double mass   = PData->mass().value() ;
+     //double mom    = sqrt(fEn*fEn-mass*mass);
+     //double px     = 0.;
+     //double py     = 0.;
+     //double pz     = mom;
+     //double energy = fEn;
+     double theta  = acos(fZ/sqrt(fR*fR + fZ*fZ)) ;
+     double mom    = pt/sin(theta) ;
+     double px     = pt*cos(phi) ;
+     double py     = pt*sin(phi) ;
+     double pz     = mom*cos(theta) ;
+     double energy2= mom*mom + mass*mass ;
+     double energy = sqrt(energy2) ; 
+ 
+     // Compute Vertex Position
+     double x=fR*cos(phi);
+     double y=fR*sin(phi);
+     constexpr double c= 2.99792458e+1; // cm/ns
+     double timeOffset = sqrt(x*x + y*y + fZ*fZ)/c*ns*c_light;
+     HepMC::GenVertex* Vtx = new HepMC::GenVertex(HepMC::FourVector(x*cm,y*cm,fZ*cm,timeOffset));
+
+     HepMC::FourVector p(px,py,pz,energy) ;
+     // If we are requested to be pointing to (0,0,0), correct the momentum direction
+     if (fPointing) {
+       math::XYZVector direction(x,y,fZ);
+       math::XYZVector momentum = direction.unit() * mom;
+       p.setX(momentum.x());
+       p.setY(momentum.y());
+       p.setZ(momentum.z());
+     }
+     HepMC::GenParticle* Part = new HepMC::GenParticle(p,PartID,1);
+     Part->suggest_barcode( barcode );
+     barcode++;
+
+     Vtx->add_particle_out(Part);
+
+     if (fVerbosity > 0) {
+       Vtx->print();
+       Part->print();
+     }
+     fEvt->add_vertex(Vtx);
+   }
+
+
+   fEvt->set_event_number(e.id().event());
+   fEvt->set_signal_process_id(20);
+
+   if ( fVerbosity > 0 )
+   {
+      fEvt->print();
+   }
+
+   unique_ptr<HepMCProduct> BProduct(new HepMCProduct());
+   BProduct->addHepMCData( fEvt );
+   e.put(std::move(BProduct), "unsmeared");
+
+   unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+   e.put(std::move(genEventInfo));
+
+   if ( fVerbosity > 0 )
+     {
+       LogDebug("CloseByParticleGunProducer") << " CloseByParticleGunProducer : Event Generation Done " << endl;
+     }
+
+   particles.clear();
+}

--- a/IOMC/ParticleGuns/src/CloseByParticleFlatEtGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleFlatEtGunProducer.cc
@@ -1,6 +1,6 @@
 #include <ostream>
 
-#include "IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h"
+#include "IOMC/ParticleGuns/interface/CloseByParticleFlatEtGunProducer.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
@@ -21,7 +21,7 @@
 using namespace edm;
 using namespace std;
 
-CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset) :
+CloseByParticleFlatEtGunProducer::CloseByParticleFlatEtGunProducer(const ParameterSet& pset) :
    BaseFlatGunProducer(pset)
 {
 
@@ -51,19 +51,19 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
 
 }
 
-CloseByParticleGunProducer::~CloseByParticleGunProducer()
+CloseByParticleFlatEtGunProducer::~CloseByParticleFlatEtGunProducer()
 {
    // no need to cleanup GenEvent memory - done in HepMCProduct
 }
 
-void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
+void CloseByParticleFlatEtGunProducer::produce(Event &e, const EventSetup& es)
 {
    edm::Service<edm::RandomNumberGenerator> rng;
    CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
 
    if ( fVerbosity > 0 )
      {
-       LogDebug("CloseByParticleGunProducer") << " CloseByParticleGunProducer : Begin New Event Generation" << endl ;
+       LogDebug("CloseByParticleFlatEtGunProducer") << " CloseByParticleFlatEtGunProducer : Begin New Event Generation" << endl ;
      }
    fEvt = new HepMC::GenEvent() ;
 
@@ -161,7 +161,7 @@ void CloseByParticleGunProducer::produce(Event &e, const EventSetup& es)
 
    if ( fVerbosity > 0 )
      {
-       LogDebug("CloseByParticleGunProducer") << " CloseByParticleGunProducer : Event Generation Done " << endl;
+       LogDebug("CloseByParticleFlatEtGunProducer") << " CloseByParticleFlatEtGunProducer : Event Generation Done " << endl;
      }
 
    particles.clear();

--- a/IOMC/ParticleGuns/src/SealModule.cc
+++ b/IOMC/ParticleGuns/src/SealModule.cc
@@ -22,6 +22,7 @@
 #include "IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h"
 #include "IOMC/ParticleGuns/interface/RandomXiThetaGunProducer.h"
 #include "IOMC/ParticleGuns/interface/ECALOverlapGunProducer.h"
+#include "IOMC/ParticleGuns/interface/CloseByParticleFlatEtGunProducer.h"
 
 // particle gun prototypes
 //
@@ -65,3 +66,7 @@ using edm::RandomXiThetaGunProducer;
 DEFINE_FWK_MODULE(RandomXiThetaGunProducer);
 using edm::ECALOverlapGunProducer;
 DEFINE_FWK_MODULE(ECALOverlapGunProducer);
+using edm::CloseByParticleFlatEtGunProducer;
+DEFINE_FWK_MODULE(CloseByParticleFlatEtGunProducer);
+
+

--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_EventContent_cff.py
@@ -53,6 +53,7 @@ RecoParticleFlowRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
     'drop CaloTowersSorted_towerMakerPF_*_*',
     #'keep recoPFRecHits_*_Cleaned_*',
+    'keep recoPFRecHits_particleFlowRecHitECAL_*_*',
     'keep recoPFRecHits_particleFlowClusterECAL_Cleaned_*',
     'keep recoPFRecHits_particleFlowClusterHCAL_Cleaned_*',
     'keep recoPFRecHits_particleFlowClusterHO_Cleaned_*',

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -5,6 +5,8 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h"
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h" //
+#include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h" //
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 
@@ -114,6 +116,7 @@ protected:
     (*eventSetup_).get<EcalPFRecHitThresholdsRcd>().get(ths);
 
     float threshold = (*ths)[hit.detId()];
+    //std::cout << "DEBUG " << " hit energy=" << hit.energy() << " hit threshold=" << threshold << std::endl;
     if (hit.energy()>threshold) return true;
 
     return false;
@@ -121,6 +124,65 @@ protected:
 };
 
 
+//
+//  M.G. Quality test that checks seeding threshold read from the DB
+//
+class PFRecHitQTestDBSeedingThreshold : public PFRecHitQTestBase {
+public:
+    PFRecHitQTestDBSeedingThreshold():eventSetup_(nullptr){
+    }
+
+    PFRecHitQTestDBSeedingThreshold(const edm::ParameterSet& iConfig):
+     PFRecHitQTestBase(iConfig),
+     applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")),    
+     eventSetup_(nullptr){
+    }
+
+    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
+        eventSetup_=&iSetup;
+    }
+
+    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
+      if (applySelectionsToAllCrystals_) return pass(hit);  
+      return fullReadOut or pass(hit);
+    }
+    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
+      return pass(hit);
+    }
+
+    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
+      return pass(hit);
+    }
+    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
+      return pass(hit);
+    }
+
+    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
+      return pass(hit);
+    }
+
+    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
+      return pass(hit);
+    }
+
+protected:
+    
+  bool applySelectionsToAllCrystals_;
+  const edm::EventSetup * eventSetup_;
+
+  
+  bool pass(const reco::PFRecHit& hit){
+
+    edm::ESHandle<EcalPFSeedingThresholds> ths;
+    (*eventSetup_).get<EcalPFSeedingThresholdsRcd>().get(ths);
+
+    float threshold = (*ths)[hit.detId()];
+    std::cout << "DEBUG seeding threshold " << " hit energy=" << hit.energy() << " hit threshold=" << threshold << std::endl;
+    if (hit.energy()>threshold) return true;
+
+    return false;
+  }
+};
 
 
 //

--- a/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
@@ -5,6 +5,9 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include <string>
 
@@ -15,6 +18,7 @@ class RecHitTopologicalCleanerBase {
   virtual ~RecHitTopologicalCleanerBase() = default;
   RecHitTopologicalCleanerBase& operator=(const RecHitTopologicalCleanerBase&) = delete;
 
+  virtual void update(const edm::EventSetup&) { }
   virtual void clean(const edm::Handle<reco::PFRecHitCollection>&, 
 		     std::vector<bool>&) = 0;
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
@@ -11,44 +11,28 @@ ECALPFSeedCleaner::ECALPFSeedCleaner(const edm::ParameterSet& conf)
 }
 
 void ECALPFSeedCleaner::update(const edm::EventSetup& iSetup) {
-  std::cout << "DEBUG ECALPFSeedCleaner::update" << std::endl;
-  //eventSetup_ = &iSetup;
-  //(*eventSetup_).get<EcalPFRecHitThresholdsRcd>().get(ths);
   iSetup.get<EcalPFSeedingThresholdsRcd>().get(ths_);
-  std::cout << "DEBUG ECALPFSeedCleaner::update 2" << std::endl;
 }
 
 void ECALPFSeedCleaner::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask ) {
 
-  //std::cout << "DEBUG ECALPFSeedCleaner::clean" << std::endl;
-  // Get thresholds from record
-  //edm::ESHandle<EcalPFRecHitThresholds> ths;
-  std::cout << "DEBUG ECALPFSeedCleaner::clean 1" << std::endl;
-  //(*eventSetup_).get<EcalPFRecHitThresholdsRcd>().get(ths);
-
-  //need to run over energy sorted rechits
+  //need to run over energy sorted rechits, as this is order used in seeding step
   // this can cause ambiguity, isn't it better to index by detid ?
   auto const & hits = *input;
   std::vector<unsigned > ordered_hits(hits.size());
   for( unsigned i = 0; i < hits.size(); ++i ) ordered_hits[i]=i;
+  //std::cout << "DEBUG: For this event I have N-rechits=" << hits.size() << std::endl;
   std::sort(ordered_hits.begin(),ordered_hits.end(),[&](unsigned i, unsigned j) { return hits[i].energy()>hits[j].energy();});
-  std::cout << "DEBUG ECALPFSeedCleaner::clean 2" << std::endl;
 
   for( const auto& idx : ordered_hits ) {
     const unsigned i = idx;
-    if( !mask[i] ) continue; // surplus ?
+    if( !mask[i] ) continue; // is it useful ?
     const reco::PFRecHit& rechit = hits[i];
-    //int hitlayer = (int)rechit.layer();
-
-    // put selection on thrs here
-    //const spike_cleaning& clean = _thresholds.find(hitlayer)->second;    
-    //if( rechit.energy() < clean._singleSpikeThresh ) continue;
 
     float threshold = (*ths_)[rechit.detId()];
-    std::cout << "DEBUG ECALPFSeedCleaner::clean 3" << std::endl;
     if (rechit.energy() < threshold) mask[i] = false;
     
-    std::cout << "DEBUG seed cleaner " << " hit energy=" << rechit.energy() << " hit threshold=" << threshold << " mask=" << mask[i] << std::endl;
+    //std::cout << "DEBUG seed cleaner " << " hit energy=" << rechit.energy() << " hit threshold=" << threshold << " mask=" << mask[i] << std::endl;
 
   } // rechit loop
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.cc
@@ -1,0 +1,54 @@
+#include "ECALPFSeedCleaner.h"
+//#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+//#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+
+#include <cmath>
+
+ECALPFSeedCleaner::ECALPFSeedCleaner(const edm::ParameterSet& conf) 
+    : RecHitTopologicalCleanerBase(conf)
+{
+//  eventSetup_ = nullptr;
+}
+
+void ECALPFSeedCleaner::update(const edm::EventSetup& iSetup) {
+  std::cout << "DEBUG ECALPFSeedCleaner::update" << std::endl;
+  //eventSetup_ = &iSetup;
+  //(*eventSetup_).get<EcalPFRecHitThresholdsRcd>().get(ths);
+  iSetup.get<EcalPFSeedingThresholdsRcd>().get(ths_);
+  std::cout << "DEBUG ECALPFSeedCleaner::update 2" << std::endl;
+}
+
+void ECALPFSeedCleaner::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask ) {
+
+  //std::cout << "DEBUG ECALPFSeedCleaner::clean" << std::endl;
+  // Get thresholds from record
+  //edm::ESHandle<EcalPFRecHitThresholds> ths;
+  std::cout << "DEBUG ECALPFSeedCleaner::clean 1" << std::endl;
+  //(*eventSetup_).get<EcalPFRecHitThresholdsRcd>().get(ths);
+
+  //need to run over energy sorted rechits
+  // this can cause ambiguity, isn't it better to index by detid ?
+  auto const & hits = *input;
+  std::vector<unsigned > ordered_hits(hits.size());
+  for( unsigned i = 0; i < hits.size(); ++i ) ordered_hits[i]=i;
+  std::sort(ordered_hits.begin(),ordered_hits.end(),[&](unsigned i, unsigned j) { return hits[i].energy()>hits[j].energy();});
+  std::cout << "DEBUG ECALPFSeedCleaner::clean 2" << std::endl;
+
+  for( const auto& idx : ordered_hits ) {
+    const unsigned i = idx;
+    if( !mask[i] ) continue; // surplus ?
+    const reco::PFRecHit& rechit = hits[i];
+    //int hitlayer = (int)rechit.layer();
+
+    // put selection on thrs here
+    //const spike_cleaning& clean = _thresholds.find(hitlayer)->second;    
+    //if( rechit.energy() < clean._singleSpikeThresh ) continue;
+
+    float threshold = (*ths_)[rechit.detId()];
+    std::cout << "DEBUG ECALPFSeedCleaner::clean 3" << std::endl;
+    if (rechit.energy() < threshold) mask[i] = false;
+    
+    std::cout << "DEBUG seed cleaner " << " hit energy=" << rechit.energy() << " hit threshold=" << threshold << " mask=" << mask[i] << std::endl;
+
+  } // rechit loop
+}

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.h
@@ -18,11 +18,7 @@ class ECALPFSeedCleaner : public RecHitTopologicalCleanerBase {
   void clean( const edm::Handle<reco::PFRecHitCollection>& input,
 	      std::vector<bool>& mask ) override;
 
-  //const edm::EventSetup* eventSetup_;
-
  private:
-  //const std::unordered_map<std::string,int> _layerMap;
-  //std::unordered_map<int,spike_cleaning> _thresholds;
   edm::ESHandle<EcalPFSeedingThresholds> ths_; 
 };
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECALPFSeedCleaner.h
@@ -1,0 +1,32 @@
+#ifndef __ECALPFSeedCleaner_H__
+#define __ECALPFSeedCleaner_H__
+
+#include "RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h"
+#include "CondFormats/EcalObjects/interface/EcalPFSeedingThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFSeedingThresholdsRcd.h"
+//#include <unordered_map>
+
+class ECALPFSeedCleaner : public RecHitTopologicalCleanerBase {
+ public:
+  
+  ECALPFSeedCleaner(const edm::ParameterSet& conf);
+  ECALPFSeedCleaner(const ECALPFSeedCleaner&) = delete;
+  ECALPFSeedCleaner& operator=(const ECALPFSeedCleaner&) = delete;
+
+  void update(const edm::EventSetup&) override;
+
+  void clean( const edm::Handle<reco::PFRecHitCollection>& input,
+	      std::vector<bool>& mask ) override;
+
+  //const edm::EventSetup* eventSetup_;
+
+ private:
+  //const std::unordered_map<std::string,int> _layerMap;
+  //std::unordered_map<int,spike_cleaning> _thresholds;
+  edm::ESHandle<EcalPFSeedingThresholds> ths_; 
+};
+
+DEFINE_EDM_PLUGIN(RecHitTopologicalCleanerFactory,
+		  ECALPFSeedCleaner,"ECALPFSeedCleaner");
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -19,11 +19,11 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf) :
   //setup rechit cleaners
   const edm::VParameterSet& cleanerConfs = 
     conf.getParameterSetVector("recHitCleaners");
-  std::cout << "DEBUG PFClusterProducer::PFClusterProducer " << std::endl;
+  //std::cout << "DEBUG PFClusterProducer::PFClusterProducer " << std::endl;
   for( const auto& conf : cleanerConfs ) {
     const std::string& cleanerName = 
       conf.getParameter<std::string>("algoName");
-    std::cout << "DEBUG PFClusterProducer::PFClusterProducer cleanerName= " << cleanerName << std::endl;
+    //std::cout << "DEBUG PFClusterProducer::PFClusterProducer cleanerName= " << cleanerName << std::endl;
     _cleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(cleanerName,conf));
   }
   edm::ConsumesCollector sumes = consumesCollector();

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
@@ -5,7 +5,7 @@ from .particleFlowCaloResolution_cfi import _timeResolutionECALBarrel, _timeReso
 
 #### PF CLUSTER ECAL ####
 
-#cleaning
+#cleaning, not used
 _spikeAndDoubleSpikeCleaner_ECAL = cms.PSet(
     algoName = cms.string("SpikeAndDoubleSpikeCleaner"),    
     cleaningByDetector = cms.VPSet(
@@ -35,7 +35,7 @@ _spikeAndDoubleSpikeCleaner_ECAL = cms.PSet(
 )
 
 
-# set-up new cleaning - in practice it's eta-dependent seeding thresholds
+# new cleaning - crystal-dependent seeding thresholds
 _seedCleaner_ECAL = cms.PSet(
      algoName = cms.string("ECALPFSeedCleaner"),
 )
@@ -45,11 +45,14 @@ _localMaxSeeds_ECAL = cms.PSet(
     algoName = cms.string("LocalMaximumSeedFinder"),
     thresholdsByDetector = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
-              seedingThreshold = cms.double(0.60),
-              seedingThresholdPt = cms.double(0.15)
+              #seedingThreshold = cms.double(0.60),
+              seedingThreshold = cms.double(0.0),
+              #seedingThresholdPt = cms.double(0.15)
+              seedingThresholdPt = cms.double(0.0)
               ),
     cms.PSet( detector = cms.string("ECAL_BARREL"),
-              seedingThreshold = cms.double(0.23),
+              #seedingThreshold = cms.double(0.23),
+              seedingThreshold = cms.double(0.0),
               seedingThresholdPt = cms.double(0.0)
               )
     ),
@@ -61,11 +64,13 @@ _topoClusterizer_ECAL = cms.PSet(
     algoName = cms.string("Basic2DGenericTopoClusterizer"),
     thresholdsByDetector = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_BARREL"),
-              gatheringThreshold = cms.double(0.08),
+              #gatheringThreshold = cms.double(0.08),
+              gatheringThreshold = cms.double(0.0),
               gatheringThresholdPt = cms.double(0.0)
               ),
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
-              gatheringThreshold = cms.double(0.3),
+              #gatheringThreshold = cms.double(0.3),
+              gatheringThreshold = cms.double(0.0),
               gatheringThresholdPt = cms.double(0.0)
               )
     ),
@@ -78,7 +83,7 @@ _positionCalcECAL_all_nodepth = cms.PSet(
     ##
     minFractionInCalc = cms.double(1e-9),
     posCalcNCrystals = cms.int32(-1),
-    logWeightDenominator = cms.double(0.08), # same as gathering threshold
+    logWeightDenominator = cms.double(0.08), # same as gathering threshold, currently not used for ECAL
     minAllowedNormalization = cms.double(1e-9),
     timeResolutionCalcBarrel = _timeResolutionECALBarrel,
     timeResolutionCalcEndcap = _timeResolutionECALEndcap,
@@ -113,10 +118,10 @@ _pfClusterizer_ECAL = cms.PSet(
     minFracTot = cms.double(1e-20), ## numerical stabilization
     recHitEnergyNorms = cms.VPSet(
     cms.PSet( detector = cms.string("ECAL_BARREL"),
-              recHitEnergyNorm = cms.double(0.08)
+              recHitEnergyNorm = cms.double(0.08) # not relevant for ECAL
               ),
     cms.PSet( detector = cms.string("ECAL_ENDCAP"),
-              recHitEnergyNorm = cms.double(0.3)
+              recHitEnergyNorm = cms.double(0.3) # not relevant for ECAL
               )
     )
 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
@@ -34,6 +34,12 @@ _spikeAndDoubleSpikeCleaner_ECAL = cms.PSet(
     )
 )
 
+
+# set-up new cleaning - in practice it's eta-dependent seeding thresholds
+_seedCleaner_ECAL = cms.PSet(
+     algoName = cms.string("ECALPFSeedCleaner"),
+)
+
 #seeding
 _localMaxSeeds_ECAL = cms.PSet(
     algoName = cms.string("LocalMaximumSeedFinder"),
@@ -118,7 +124,7 @@ _pfClusterizer_ECAL = cms.PSet(
 particleFlowClusterECALUncorrected = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitECAL"),
-    recHitCleaners = cms.VPSet(),
+    recHitCleaners = cms.VPSet(_seedCleaner_ECAL), 
     seedFinder = _localMaxSeeds_ECAL,
     initialClusteringStep = _topoClusterizer_ECAL,
     pfClusterBuilder = _pfClusterizer_ECAL,


### PR DESCRIPTION
Ciao @bmarzocc ,

I have set up the code to have seeding thresholds which are crystal-dependent. 
The thresholds are accessed via a newly created record. I tested the code and it's working as expected.

There is a caveat: the record for the crystal dependent seeding thresholds does not exist in the database and has to be created via an EcalTrivialConditionRetriever, which must be configured appropriately in the cmsdriver of the RECO step. 

So this version of the code does not work unless there are appropriate changes in the configuration file of the RECO step.

If you agree, I could also open a pull request under https://github.com/bmarzocc/RecoSimStudies to include changes to https://github.com/bmarzocc/RecoSimStudies/blob/master/Dumpers/test/step3_RAW2DIGI_L1Reco_RECO_RECOSIM_EI_PAT_VALIDATION_DQM.py

What do you think?

Thanks,
Maria Giulia
